### PR TITLE
Recommend VSCode extension for Azure Cosmos DB

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,16 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/go:1",
+  "image": "mcr.microsoft.com/devcontainers/go:1.23",
   "features": {
-    "ghcr.io/devcontainers/features/azure-cli:1": {},
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/azure/azure-dev/azd:0": {}
+    "ghcr.io/azure/azure-dev/azd": {},
+    "ghcr.io/devcontainers/features/azure-cli": {},
+    "ghcr.io/devcontainers/features/docker-in-docker": {}
   },
   "customizations": {
     "vscode": {
       "extensions": [
-        "golang.Go"
+        "golang.Go",
+        "ms-azuretools.vscode-cosmosdb"
       ]
     }
-  },
-  "updateContentCommand": "go install honnef.co/go/tools/cmd/staticcheck@latest"
+  }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-cosmosdb"
+  ]
+}


### PR DESCRIPTION
Per @meredithmooreux recommendation, updating the extension recommendations and Dockerfile:

- [x] Auto-install Azure Cosmos DB extension in devcontainer
- [x] Recommend Azure Cosmos DB extension in local dev

> [!NOTE]
> This PR also streamlines the Dockerfile to match the upstream repository